### PR TITLE
Rebrand from Twins to Refolk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Twins Project - Claude Guidelines
+# Refolk Project - Claude Guidelines
 
 ## Understanding This Project
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,22 @@
-# Digital Customer Twins
+# Refolk
 
-*Automatically synced with your [v0.app](https://v0.app) deployments*
+AI-powered customer personas you can actually talk to. Get real feedback, test messaging, and validate ideas — without the cost, time, or risk of real user research.
 
-[![Deployed on Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=for-the-badge&logo=vercel)](https://vercel.com/youngchingjuis-projects/v0-digital-customer-twins)
-[![Built with v0](https://img.shields.io/badge/Built%20with-v0.app-black?style=for-the-badge)](https://v0.app/chat/kilQpyBuAiL)
+## Stack
 
-## Overview
+- **Frontend:** Next.js 16, React 19, TypeScript
+- **Styling:** Tailwind CSS v4, Radix UI / shadcn/ui
+- **Runtime:** Bun
+- **Deployment:** Vercel
 
-This repository will stay in sync with your deployed chats on [v0.app](https://v0.app).
-Any changes you make to your deployed app will be automatically pushed to this repository from [v0.app](https://v0.app).
+## Development
 
-## Deployment
+```bash
+bun install
+bun run dev
+```
 
-Your project is live at:
+## Links
 
-**[https://vercel.com/youngchingjuis-projects/v0-digital-customer-twins](https://vercel.com/youngchingjuis-projects/v0-digital-customer-twins)**
-
-## Build your app
-
-Continue building your app on:
-
-**[https://v0.app/chat/kilQpyBuAiL](https://v0.app/chat/kilQpyBuAiL)**
-
-## How It Works
-
-1. Create and modify your project using [v0.app](https://v0.app)
-2. Deploy your chats from the v0 interface
-3. Changes are automatically pushed to this repository
-4. Vercel deploys the latest version from this repository
+- **Live site:** [refolk.co](https://refolk.co)
+- **Production Deployment:** [Vercel](https://vercel.com/youngchingjui/refolk)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export const viewport = {
 }
 
 export const metadata: Metadata = {
-  title: 'Twins — Digital Customer Twins',
+  title: 'Refolk — AI Customer Personas',
   description: 'Turn customer personas into living, conversational simulations. Test ideas with customers before customers ever exist.',
   generator: 'v0.app',
   icons: {

--- a/components/chat-demo.tsx
+++ b/components/chat-demo.tsx
@@ -11,30 +11,30 @@ const personas = [
   { id: "linda", name: "Linda Okafor", avatar: "L" },
 ]
 
-const conversations: Record<string, Array<{ role: "user" | "twin"; content: string; attachment?: string }>> = {
+const conversations: Record<string, Array<{ role: "user" | "persona"; content: string; attachment?: string }>> = {
   maya: [
     { role: "user", content: "Hey Maya, we're thinking about adding an AI assistant to our product. It would help users write better reports. What's your initial reaction?" },
-    { role: "twin", content: "Honestly? My first thought is 'here we go again.' We've tried two AI writing tools and both were useless. The output was so generic we had to rewrite everything anyway." },
+    { role: "persona", content: "Honestly? My first thought is 'here we go again.' We've tried two AI writing tools and both were useless. The output was so generic we had to rewrite everything anyway." },
     { role: "user", content: "What would make you actually try it?" },
-    { role: "twin", content: "Show me it working on MY data, not some demo. Let me try it free for a month—not 14 days, that's not enough time to really test anything. And don't make me talk to sales to get the trial." },
+    { role: "persona", content: "Show me it working on MY data, not some demo. Let me try it free for a month—not 14 days, that's not enough time to really test anything. And don't make me talk to sales to get the trial." },
     { role: "user", content: "What if we showed you case studies from similar companies?" },
-    { role: "twin", content: "Case studies are fine but I've seen too many that are basically ads. What I actually want is to talk to a real customer. If you can connect me with a PM at a similar-stage company who's been using it for 6+ months, that's worth more than any case study." },
+    { role: "persona", content: "Case studies are fine but I've seen too many that are basically ads. What I actually want is to talk to a real customer. If you can connect me with a PM at a similar-stage company who's been using it for 6+ months, that's worth more than any case study." },
   ],
   marcus: [
     { role: "user", content: "Marcus, I want to show you a new email design for our product launch. Can you take a look?", attachment: "campaign-mockup.png" },
-    { role: "twin", content: "Yeah, let me see... Okay, the design is clean but the headline 'Revolutionize Your Routine' doesn't tell me anything. What am I actually getting? I don't have time to figure it out." },
+    { role: "persona", content: "Yeah, let me see... Okay, the design is clean but the headline 'Revolutionize Your Routine' doesn't tell me anything. What am I actually getting? I don't have time to figure it out." },
     { role: "user", content: "What would make you click?" },
-    { role: "twin", content: "Tell me the specific thing. 'Face wash that doesn't leave white residue on dark skin' — that's a headline I'd click. I'm not looking for revolutionary, I'm looking for 'this person gets my actual problem.'" },
+    { role: "persona", content: "Tell me the specific thing. 'Face wash that doesn't leave white residue on dark skin' — that's a headline I'd click. I'm not looking for revolutionary, I'm looking for 'this person gets my actual problem.'" },
     { role: "user", content: "Would you forward this to a friend?" },
-    { role: "twin", content: "Not this version. If it was more specific, maybe. But you know what would really make me forward it? If there was a referral discount. I'm watching my runway and so are my founder friends. 'Send to a friend, you both get 20%' — I'd do that." },
+    { role: "persona", content: "Not this version. If it was more specific, maybe. But you know what would really make me forward it? If there was a referral discount. I'm watching my runway and so are my founder friends. 'Send to a friend, you both get 20%' — I'd do that." },
   ],
   linda: [
     { role: "user", content: "Linda, we're debating whether to launch a TikTok strategy. What's your take?" },
-    { role: "twin", content: "My gut says our buyers aren't on TikTok. They're enterprise IT directors, mostly 40+. But I've been wrong before—I didn't think LinkedIn would work for us either and now it's our best channel." },
+    { role: "persona", content: "My gut says our buyers aren't on TikTok. They're enterprise IT directors, mostly 40+. But I've been wrong before—I didn't think LinkedIn would work for us either and now it's our best channel." },
     { role: "user", content: "How would you make the case internally?" },
-    { role: "twin", content: "I'd need data I can show the CFO. 'Competitor X is doing it' isn't enough. Give me: what's the reach to our ICP, what's the cost per thousand compared to our current channels, and what's a realistic timeline to see results. If it's 18 months before we know if it's working, that's a harder sell." },
+    { role: "persona", content: "I'd need data I can show the CFO. 'Competitor X is doing it' isn't enough. Give me: what's the reach to our ICP, what's the cost per thousand compared to our current channels, and what's a realistic timeline to see results. If it's 18 months before we know if it's working, that's a harder sell." },
     { role: "user", content: "What would the content even look like for B2B enterprise?" },
-    { role: "twin", content: "That's the part I'm not sure about. Our brand is... serious. Professional. I don't know if that translates. But maybe that's the opportunity? If everyone else in our space is doing boring whitepapers and we're doing something human, maybe that stands out. I'd want to test it small before committing real budget." },
+    { role: "persona", content: "That's the part I'm not sure about. Our brand is... serious. Professional. I don't know if that translates. But maybe that's the opportunity? If everyone else in our space is doing boring whitepapers and we're doing something human, maybe that stands out. I'd want to test it small before committing real budget." },
   ],
 }
 
@@ -68,7 +68,7 @@ export function ChatDemo() {
             A conversation, not a survey
           </h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
-            Upload documents, images, or campaign mockups. The twin responds in character—with 
+            Upload documents, images, or campaign mockups. The persona responds in character—with
             the hesitations, skepticism, and enthusiasm of a real person with their specific history.
           </p>
         </div>
@@ -163,7 +163,7 @@ export function ChatDemo() {
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSendDemo()}
-                placeholder="Ask the twin anything..."
+                placeholder="Ask the persona anything..."
                 className="flex-1 bg-transparent text-base outline-none placeholder:text-muted-foreground min-h-[44px]"
               />
               <Button 
@@ -175,7 +175,7 @@ export function ChatDemo() {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground mt-3">
-              Upload PDFs, images, or paste URLs. Twins can review landing pages, ads, decks, and product mockups.
+              Upload PDFs, images, or paste URLs. Personas can review landing pages, ads, decks, and product mockups.
             </p>
           </div>
         </div>

--- a/components/difference.tsx
+++ b/components/difference.tsx
@@ -37,7 +37,7 @@ export function Difference() {
           </div>
 
           <div className="p-8 rounded-lg border-2 border-primary bg-card">
-            <h3 className="text-lg font-medium">Digital twins</h3>
+            <h3 className="text-lg font-medium">Refolk personas</h3>
             <ul className="mt-6 space-y-4">
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-foreground shrink-0 mt-0.5" />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -11,12 +11,12 @@ export function Footer() {
             Your customers already have opinions about your product. Now you can hear them.
           </h2>
           <p className="mt-6 text-muted-foreground leading-relaxed">
-            Every day you wait is another day building on assumptions. Start talking to 
-            your twins today.
+            Every day you wait is another day building on assumptions. Start talking to
+            your personas today.
           </p>
           <Button size="lg" asChild className="mt-8 h-12 px-8 text-base">
             <Link href="#pricing">
-              Build your first twin
+              Build your first persona
               <ArrowRight className="ml-2 w-4 h-4" />
             </Link>
           </Button>
@@ -27,10 +27,10 @@ export function Footer() {
         <div className="max-w-6xl mx-auto px-6 py-6 flex flex-col md:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-6">
             <Link href="/" className="font-medium tracking-tight">
-              twins
+              refolk
             </Link>
             <span className="text-sm text-muted-foreground">
-              © 2026 Twins, Inc.
+              © 2026 Refolk, Inc.
             </span>
           </div>
           <div className="flex items-center gap-6 text-sm text-muted-foreground">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -12,7 +12,7 @@ export function Header() {
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-sm border-b border-border">
       <nav className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
         <Link href="/" className="font-medium text-lg tracking-tight">
-          twins
+          refolk
         </Link>
 
         <div className="hidden md:flex items-center gap-8">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -11,8 +11,8 @@ export function Hero() {
         </h1>
         
         <p className="mt-6 md:mt-8 text-lg md:text-xl text-muted-foreground leading-relaxed max-w-2xl">
-          Digital Customer Twins are AI-powered representations of your customers that you can actually 
-          converse with. Ask them questions. Test your messaging. Understand their objections. 
+          Refolk personas are AI-powered representations of your customers that you can actually
+          converse with. Ask them questions. Test your messaging. Understand their objections.
           Before you spend a dollar on research or a month building the wrong thing.
         </p>
 

--- a/components/how-it-works.tsx
+++ b/components/how-it-works.tsx
@@ -7,10 +7,10 @@ export function HowItWorks() {
             How it works
           </p>
           <h2 className="mt-4 text-3xl md:text-4xl font-medium tracking-tight text-balance">
-            A twin is not a persona. It{"'"}s a person.
+            More than a persona. A person.
           </h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
-            Traditional personas are flat documents. A twin is a coherent individual with a history, 
+            Traditional personas are flat documents. Ours are coherent individuals with a history,
             values, anxieties, and decision-making patterns that persist across every interaction.
           </p>
         </div>
@@ -34,7 +34,7 @@ export function HowItWorks() {
             <h3 className="text-lg font-medium">Build the backstory</h3>
             <p className="text-muted-foreground leading-relaxed">
               Childhood context. Formative experiences. Career trajectory. Relationship history. 
-              This is what gives the twin psychological realism—the texture that makes responses feel human.
+              This is what gives the persona psychological realism—the texture that makes responses feel human.
             </p>
           </div>
 
@@ -77,8 +77,8 @@ export function HowItWorks() {
             </div>
             <h3 className="text-lg font-medium">Iterate without cost</h3>
             <p className="text-muted-foreground leading-relaxed">
-              Run the same test with different twins. Change variables. The twin is available 
-              24/7, responds in seconds, and never gets tired of your questions.
+              Run the same test with different personas. Change variables. They{"'"}re available
+              24/7, respond in seconds, and never get tired of your questions.
             </p>
           </div>
         </div>

--- a/components/integrations.tsx
+++ b/components/integrations.tsx
@@ -46,7 +46,7 @@ function SlackMockup() {
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-2">
               <span className="font-bold text-white">Maya Chen</span>
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Twin</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Persona</span>
               <span className="text-xs text-[#9a9b9d]">2:35 PM</span>
             </div>
             <p className="mt-1 leading-relaxed">
@@ -63,7 +63,7 @@ function SlackMockup() {
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-2">
               <span className="font-bold text-white">Marcus Johnson</span>
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Twin</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Persona</span>
               <span className="text-xs text-[#9a9b9d]">2:36 PM</span>
             </div>
             <p className="mt-1 leading-relaxed">
@@ -80,7 +80,7 @@ function SlackMockup() {
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-2">
               <span className="font-bold text-white">Linda Okafor</span>
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Twin</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[#4a154b] text-[#e8a5e9]">Persona</span>
               <span className="text-xs text-[#9a9b9d]">2:37 PM</span>
             </div>
             <p className="mt-1 leading-relaxed">
@@ -243,11 +243,11 @@ function CICDMockup() {
           <span className="text-xs text-emerald-500 ml-auto">passed</span>
         </div>
         
-        {/* Twin review - warning */}
+        {/* Persona review - warning */}
         <div className="border border-yellow-500/30 rounded-md p-3 bg-yellow-500/5">
           <div className="flex items-center gap-3">
             <AlertCircle className="w-4 h-4 text-yellow-500" />
-            <span className="text-yellow-400 font-medium">twins/maya-review</span>
+            <span className="text-yellow-400 font-medium">refolk/maya-review</span>
             <span className="text-xs text-yellow-500 ml-auto">flagged</span>
           </div>
           <div className="mt-3 pl-7 text-[#8b949e] text-xs leading-relaxed">
@@ -258,12 +258,12 @@ function CICDMockup() {
 
         <div className="flex items-center gap-3">
           <Check className="w-4 h-4 text-emerald-500" />
-          <span className="text-[#8b949e]">twins/marcus-review</span>
+          <span className="text-[#8b949e]">refolk/marcus-review</span>
           <span className="text-xs text-emerald-500 ml-auto">approved</span>
         </div>
         <div className="flex items-center gap-3">
           <Check className="w-4 h-4 text-emerald-500" />
-          <span className="text-[#8b949e]">twins/linda-review</span>
+          <span className="text-[#8b949e]">refolk/linda-review</span>
           <span className="text-xs text-emerald-500 ml-auto">approved</span>
         </div>
       </div>
@@ -272,7 +272,7 @@ function CICDMockup() {
       <div className="px-4 py-3 border-t border-[#30363d] bg-[#161b22]">
         <div className="flex items-center gap-2 text-xs text-[#8b949e]">
           <X className="w-4 h-4 text-red-500" />
-          <span>Merging is blocked — 1 twin concern requires resolution</span>
+          <span>Merging is blocked — 1 persona concern requires resolution</span>
         </div>
       </div>
     </div>
@@ -354,11 +354,11 @@ export function Integrations() {
             Where you already work
           </p>
           <h2 className="mt-4 text-3xl md:text-4xl font-medium tracking-tight text-balance">
-            Twins that show up in your workflow
+            Personas that show up in your workflow
           </h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
-            Tag a twin in Slack. Get email open predictions before you send. Block deploys until 
-            user-facing copy passes twin review. Set up webhooks that trigger twin reactions 
+            Tag a persona in Slack. Get email open predictions before you send. Block deploys until
+            user-facing copy passes persona review. Set up webhooks that trigger persona reactions
             whenever you ship something new.
           </p>
         </div>
@@ -395,8 +395,8 @@ export function Integrations() {
         <div className="mt-12 p-6 border border-border rounded-lg bg-muted/30">
           <p className="text-sm text-muted-foreground leading-relaxed">
             <span className="font-medium text-foreground">API access included on Team and Enterprise plans.</span>
-            {" "}Build custom integrations, trigger twin conversations from your own systems, 
-            or embed twin feedback into internal tools.
+            {" "}Build custom integrations, trigger persona conversations from your own systems,
+            or embed persona feedback into internal tools.
           </p>
         </div>
       </div>

--- a/components/personas.tsx
+++ b/components/personas.tsx
@@ -8,7 +8,7 @@ const personas = [
   {
     id: "maya",
     name: "Maya Chen",
-    subtitle: "34, cis-female, product lead at Series B fintech, married, 2 kids",
+    subtitle: "34, female, product lead at Series B fintech, married, 2 kids",
     avatar: "M",
     shortBio: "Skeptical of new tools—burned twice by vendors who overpromised. Needs proof before she'll champion anything internally.",
     backstory: `Maya grew up in a household where money was discussed openly—her parents ran a small restaurant and she saw firsthand what happens when cash flow gets tight. She studied engineering but moved into product because she loved the human side of building things.
@@ -22,7 +22,7 @@ She has two kids under 5, so her time is fragmented. She does deep work between 
   {
     id: "marcus",
     name: "Marcus Johnson", 
-    subtitle: "28, cis-male, bootstrapped DTC founder, single, Brooklyn",
+    subtitle: "28, male, bootstrapped DTC founder, single, Brooklyn",
     avatar: "MJ",
     shortBio: "First-time founder running lean. Makes fast decisions but watches every dollar. Knows his customers by name.",
     backstory: `Marcus left his consulting job 18 months ago to start a skincare line focused on men with darker skin tones—a market he felt was underserved after years of buying products that left white residue or didn't match his needs.
@@ -36,7 +36,7 @@ His customers DM him directly on Instagram. He reads every message. He knows the
   {
     id: "linda",
     name: "Linda Okafor",
-    subtitle: "52, cis-female, VP Marketing at enterprise SaaS, divorced, grandmother",
+    subtitle: "52, female, VP Marketing at enterprise SaaS, divorced, grandmother",
     avatar: "L",
     shortBio: "20+ years in marketing. Trusts her gut but learned that 'I just know' doesn't work in exec meetings anymore.",
     backstory: `Linda has been in marketing since before Google existed. She's seen channels come and go—she ran direct mail campaigns, then email, then social, now she's figuring out what AI means for her team.
@@ -57,13 +57,13 @@ export function Personas() {
       <div className="max-w-6xl mx-auto">
         <div className="max-w-2xl">
           <p className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
-            Meet the twins
+            Meet the personas
           </p>
           <h2 className="mt-4 text-3xl md:text-4xl font-medium tracking-tight text-balance">
             Real people with real histories
           </h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
-            These aren{"'"}t archetypes or marketing segments. Each twin has a childhood, a career 
+            These aren{"'"}t archetypes or marketing segments. Each persona has a childhood, a career
             trajectory, anxieties, and patterns of behavior that shape how they respond to everything you show them.
           </p>
         </div>
@@ -116,10 +116,10 @@ export function Personas() {
                 <Plus className="w-5 h-5 text-muted-foreground" />
               </div>
               <div className="flex-1 min-w-0">
-                <h3 className="font-medium text-muted-foreground">Build your own twin</h3>
+                <h3 className="font-medium text-muted-foreground">Build your own persona</h3>
                 <p className="text-sm text-muted-foreground mt-0.5">Create a custom persona for your specific audience</p>
                 <p className="text-sm text-muted-foreground/70 mt-2 leading-relaxed">
-                  Upload customer interviews, support tickets, survey responses. We{"'"}ll help you construct a twin from real data.
+                  Upload customer interviews, support tickets, survey responses. We{"'"}ll help you construct a persona from real data.
                 </p>
               </div>
             </button>

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -11,7 +11,7 @@ export function Pricing() {
             Pricing
           </p>
           <h2 className="mt-4 text-3xl md:text-4xl font-medium tracking-tight text-balance">
-            One twin costs less than one focus group participant
+            One persona costs less than one focus group participant
           </h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
             A single focus group runs $5,000–$15,000 and gives you two hours of

--- a/components/use-cases.tsx
+++ b/components/use-cases.tsx
@@ -16,7 +16,7 @@ export function UseCases() {
             <div>
               <h3 className="text-xl font-medium">Test messaging before you ship it</h3>
               <p className="mt-4 text-muted-foreground leading-relaxed">
-                Show your twin an ad, a tagline, a landing page. They{"'"}ll tell you what feels off. 
+                Show your persona an ad, a tagline, a landing page. They{"'"}ll tell you what feels off.
                 {'"'}This detergent says it{"'"}s eco-friendly but feels vague. Is it actually better, 
                 or just more expensive?{'"'} You get real objections in human language, not survey data.
               </p>
@@ -25,7 +25,7 @@ export function UseCases() {
               <p className="text-sm text-muted-foreground font-medium mb-3">Example conversation</p>
               <div className="space-y-3 text-sm">
                 <p><span className="font-medium">You:</span> What do you think of this headline: {'"'}The future of clean, delivered{'"'}?</p>
-                <p><span className="font-medium">Twin:</span> It sounds nice but I have no idea what you{"'"}re selling. Delivered how? What{"'"}s clean? I{"'"}d scroll past this.</p>
+                <p><span className="font-medium">Persona:</span> It sounds nice but I have no idea what you{"'"}re selling. Delivered how? What{"'"}s clean? I{"'"}d scroll past this.</p>
               </div>
             </div>
           </div>
@@ -34,7 +34,7 @@ export function UseCases() {
             <div>
               <h3 className="text-xl font-medium">Kill bad ideas before you build them</h3>
               <p className="mt-4 text-muted-foreground leading-relaxed">
-                Before your team spends three months building a feature, ask a twin: Would you actually 
+                Before your team spends three months building a feature, ask a persona: Would you actually
                 use this? What would confuse you? What feels unnecessary? Refine feature prioritization 
                 and reduce expensive real-world testing loops.
               </p>
@@ -43,7 +43,7 @@ export function UseCases() {
               <p className="text-sm text-muted-foreground font-medium mb-3">Example conversation</p>
               <div className="space-y-3 text-sm">
                 <p><span className="font-medium">You:</span> We{"'"}re thinking of adding social features—you could see what your friends bought.</p>
-                <p><span className="font-medium">Twin:</span> I don{"'"}t want my friends knowing what I buy. That feels invasive. I{"'"}d probably turn it off immediately.</p>
+                <p><span className="font-medium">Persona:</span> I don{"'"}t want my friends knowing what I buy. That feels invasive. I{"'"}d probably turn it off immediately.</p>
               </div>
             </div>
           </div>
@@ -52,7 +52,7 @@ export function UseCases() {
             <div>
               <h3 className="text-xl font-medium">End opinion-driven debates</h3>
               <p className="mt-4 text-muted-foreground leading-relaxed">
-                When product, marketing, and design disagree about what customers want, bring in the twin. 
+                When product, marketing, and design disagree about what customers want, bring in the persona.
                 Everyone can consult the same customer. The conversation shifts from {'"'}I think{'"'} to 
                 {'"'}let{"'"}s ask.{'"'}
               </p>
@@ -61,7 +61,7 @@ export function UseCases() {
               <p className="text-sm text-muted-foreground font-medium mb-3">Example conversation</p>
               <div className="space-y-3 text-sm">
                 <p><span className="font-medium">Designer:</span> Should the checkout be one page or multi-step?</p>
-                <p><span className="font-medium">Twin:</span> I prefer seeing everything at once. When it{"'"}s split into steps I worry there{"'"}s hidden fees coming.</p>
+                <p><span className="font-medium">Persona:</span> I prefer seeing everything at once. When it{"'"}s split into steps I worry there{"'"}s hidden fees coming.</p>
               </div>
             </div>
           </div>

--- a/docs/marketing/cta-guidelines.md
+++ b/docs/marketing/cta-guidelines.md
@@ -34,7 +34,7 @@ A CTA should be **clear about what happens when you click it**, not just aspirat
 
 ### 1. Interactive Demo (above the fold)
 
-- User can actually talk to a twin right there
+- User can actually talk to a persona right there
 - CTA within demo: "Ask Maya" or "Send a message"
 - This is the "try it" moment
 

--- a/docs/marketing/how-it-works-rewrite.md
+++ b/docs/marketing/how-it-works-rewrite.md
@@ -19,11 +19,11 @@ The current "How It Works" section **completely contradicts the value propositio
 
 The actual user journey is:
 
-1. ✅ **Browse the roster** - See the twins we've already built
+1. ✅ **Browse the roster** - See the personas we've already built
 2. ✅ **Pick your perspectives** - Choose 3 (Starter) or 50+ (Team) personas
 3. ✅ **Connect to your channels** - Add them to Slack, Email, etc.
 4. ✅ **Start asking questions** - Get immediate feedback
-5. ✅ **Iterate freely** - Ask follow-ups, test variations, try different twins
+5. ✅ **Iterate freely** - Ask follow-ups, test variations, try different personas
 
 ## Key Messaging Shift
 
@@ -36,7 +36,7 @@ The actual user journey is:
 
 ### NEW (correct)
 
-- Emphasizes twins are already built
+- Emphasizes personas are already built
 - Shows how simple it is to start using
 - Reinforces "we've done the hard work" message
 - Removes friction, shows speed
@@ -53,7 +53,7 @@ The actual user journey is:
 
 ### 3. Connect your channels
 
-"Add twins to Slack, Email, or wherever you work. They're available 24/7, respond in seconds."
+"Add personas to Slack, Email, or wherever you work. They're available 24/7, respond in seconds."
 
 ### 4. Start asking questions
 
@@ -61,11 +61,11 @@ The actual user journey is:
 
 ### 5. Iterate without limits
 
-"Ask follow-ups. Try different approaches. Test on multiple personas. The twins never get tired, never need scheduling, never cost extra."
+"Ask follow-ups. Try different approaches. Test on multiple personas. The personas never get tired, never need scheduling, never cost extra."
 
-## What About Custom Twins?
+## What About Custom Personas?
 
-Custom twin creation should be:
+Custom persona creation should be:
 
 - Mentioned as a **Team/Enterprise feature** (not the default path)
 - Positioned as "advanced" or "optional"
@@ -73,7 +73,7 @@ Custom twin creation should be:
 
 Something like:
 
-> "Need a highly specific persona? Team and Enterprise customers can request custom twins tailored to your exact audience."
+> "Need a highly specific persona? Team and Enterprise customers can request custom personas tailored to your exact audience."
 
 ## Implementation
 

--- a/docs/tech/monetization-setup-complete.md
+++ b/docs/tech/monetization-setup-complete.md
@@ -1,0 +1,229 @@
+# Refolk Monetization Setup - Complete ✅
+
+**Date:** 2026-02-09
+**Status:** TEST MODE READY - Needs live mode setup before production launch
+
+## What's Been Completed
+
+### 1. ✅ Pricing Model Defined
+
+All documentation updated to reflect final pricing:
+
+- **Starter:** $50/month - 3 curated personas
+- **Team:** $300/month - 30 curated personas
+- **Enterprise:** Custom pricing - Unlimited personas
+
+Updated files:
+
+- `docs/user/reqs.md`
+- `docs/marketing/pricing-strategy.md`
+- `components/pricing.tsx`
+
+### 2. ✅ Stripe Products Created (Test Mode)
+
+Created via Stripe CLI:
+
+**Starter Product:**
+
+- Product ID: `prod_Twe1k8umIIvGMD`
+- Price ID: `price_1SykjtJJUWoGcvyBJYLgYFgG`
+- Amount: $50/month (5000 cents)
+
+**Team Product:**
+
+- Product ID: `prod_Twe20xdy02kZcn`
+- Price ID: `price_1SykkpJJUWoGcvyBARHlM9xZ`
+- Amount: $300/month (30000 cents)
+
+### 3. ✅ Stripe Payment Links Created (Test Mode)
+
+**Starter Payment Link:**
+
+```
+https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00
+```
+
+**Team Payment Link:**
+
+```
+https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01
+```
+
+Features configured:
+
+- ✅ Allow promotion codes
+- ✅ Custom confirmation message
+- ✅ Automatic email collection
+
+### 4. ✅ Environment Variables Configured
+
+Created `.env.local` with test payment links:
+
+```bash
+NEXT_PUBLIC_STRIPE_STARTER_LINK=https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00
+NEXT_PUBLIC_STRIPE_TEAM_LINK=https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01
+```
+
+### 5. ✅ Local Testing Complete
+
+- Dev server running on port 3000
+- Payment links verified in page source
+- Buttons functional on pricing section
+
+## Next Steps (Before Production Launch)
+
+### 1. Add Environment Variables to Vercel
+
+**Manual method (Recommended):**
+
+1. Go to https://vercel.com/youngchingjuis-projects/refolk/settings/environment-variables
+2. Add these two variables for **all environments** (Production, Preview, Development):
+
+```
+NEXT_PUBLIC_STRIPE_STARTER_LINK = https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00
+NEXT_PUBLIC_STRIPE_TEAM_LINK = https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01
+```
+
+3. Trigger a new deployment (push to main or click "Redeploy")
+
+**CLI method (if preferred):**
+
+```bash
+# For each variable, for each environment:
+echo "https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00" | vercel env add NEXT_PUBLIC_STRIPE_STARTER_LINK production
+echo "https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00" | vercel env add NEXT_PUBLIC_STRIPE_STARTER_LINK preview
+echo "https://buy.stripe.com/test_4gMcN6geR42qgmsbr0asg00" | vercel env add NEXT_PUBLIC_STRIPE_STARTER_LINK development
+
+echo "https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01" | vercel env add NEXT_PUBLIC_STRIPE_TEAM_LINK production
+echo "https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01" | vercel env add NEXT_PUBLIC_STRIPE_TEAM_LINK preview
+echo "https://buy.stripe.com/test_6oUcN6d2F42qgms66Gasg01" | vercel env add NEXT_PUBLIC_STRIPE_TEAM_LINK development
+```
+
+### 2. Test the Purchase Flow
+
+**Test Mode Testing:**
+
+1. Visit your deployed site
+2. Click "Start getting feedback" or "Talk to the roster" buttons
+3. Use Stripe test card: `4242 4242 4242 4242`
+4. Use any future expiry date and any CVC
+5. Complete the purchase
+6. Verify confirmation message appears
+7. Check Stripe dashboard for the test subscription
+
+**Dashboard:** https://dashboard.stripe.com/test/subscriptions
+
+### 3. Create Live Mode Products & Links
+
+When ready to accept real payments:
+
+```bash
+# Switch to live mode
+stripe products create \
+  --name="Refolk - Starter" \
+  --description="Access to 3 digital customer personas with Slack and Email integrations" \
+  --live
+
+# Get the product ID from output, then create price
+stripe prices create \
+  --product="prod_XXXXX" \
+  --unit-amount=5000 \
+  --currency=usd \
+  --recurring.interval=month \
+  --nickname="Starter Monthly" \
+  --live
+
+# Create payment link
+stripe payment_links create \
+  -d "line_items[0][price]=price_XXXXX" \
+  -d "line_items[0][quantity]=1" \
+  --after-completion.type=hosted_confirmation \
+  --after-completion.hosted-confirmation.custom-message="Thank you for subscribing to Refolk! We'll be in touch shortly with onboarding instructions." \
+  --allow-promotion-codes=true \
+  --live
+
+# Repeat for Team product...
+```
+
+Then update `.env.local` and Vercel environment variables with the live links.
+
+### 4. Set Up Stripe Webhooks (Future)
+
+For automated onboarding, you'll need:
+
+1. Create webhook endpoint in your app
+2. Listen for these events:
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+3. Automate account creation and access provisioning
+
+See: https://docs.stripe.com/webhooks
+
+### 5. Post-Purchase Flow (Current: Manual)
+
+Right now, when someone subscribes:
+
+1. You'll get email notification from Stripe
+2. Manually send welcome email with:
+   - Thank you message
+   - Onboarding instructions
+   - Contact information
+
+**Future:** Automate this with webhooks + email service.
+
+## Testing Checklist
+
+- [x] Products created in Stripe test mode
+- [x] Payment links created and configured
+- [x] Environment variables set locally
+- [x] Links verified in local dev server
+- [ ] Environment variables added to Vercel
+- [ ] Test purchase flow on deployed site
+- [ ] Verify Stripe dashboard shows test subscription
+- [ ] Test promotion codes work
+- [ ] Create live mode products (when ready)
+- [ ] Switch to live payment links (when ready)
+
+## Files Changed
+
+- ✅ `docs/user/reqs.md` - Updated to 30 personas
+- ✅ `docs/marketing/pricing-strategy.md` - Updated to 30 personas
+- ✅ `.env.local` - Created with test payment links
+- ✅ `.env.local.example` - Already existed
+- ✅ `components/pricing.tsx` - Already configured to use env vars
+
+## Stripe CLI Commands Reference
+
+```bash
+# View products
+stripe products list
+
+# View prices
+stripe prices list
+
+# View payment links
+stripe payment_links list
+
+# View test subscriptions
+stripe subscriptions list
+
+# Listen to webhooks locally (for development)
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+```
+
+## Dashboard Links
+
+- **Test Dashboard:** https://dashboard.stripe.com/test/dashboard
+- **Live Dashboard:** https://dashboard.stripe.com/dashboard
+- **Products:** https://dashboard.stripe.com/test/products
+- **Payment Links:** https://dashboard.stripe.com/test/payment-links
+- **Subscriptions:** https://dashboard.stripe.com/test/subscriptions
+- **Customers:** https://dashboard.stripe.com/test/customers
+
+---
+
+**Task #28 Status: COMPLETE** ✅
+
+Pricing model defined, Stripe products created, payment links working locally.
+Next: Add env vars to Vercel and test deployed purchase flow.

--- a/docs/tech/stripe-setup.md
+++ b/docs/tech/stripe-setup.md
@@ -18,20 +18,20 @@ Go to [stripe.com](https://stripe.com) and sign up or log in.
 
 Navigate to **Products** in the Stripe dashboard, then create:
 
-#### Product 1: Twins - Starter
+#### Product 1: Refolk - Starter
 
-- **Name:** Twins - Starter
-- **Description:** Access to digital customer twins with Slack and Email integrations
+- **Name:** Refolk - Starter
+- **Description:** Access to AI customer personas with Slack and Email integrations
 - **Pricing:**
   - Type: Recurring
   - Price: $50 USD
   - Billing period: Monthly
   - Currency: USD
 
-#### Product 2: Twins - Team
+#### Product 2: Refolk - Team
 
-- **Name:** Twins - Team
-- **Description:** Full team access with custom twin creation and API access
+- **Name:** Refolk - Team
+- **Description:** Full team access with custom persona creation and API access
 - **Pricing:**
   - Type: Recurring
   - Price: $300 USD

--- a/docs/user/reqs.md
+++ b/docs/user/reqs.md
@@ -1,4 +1,4 @@
-# Twins - User Requirements
+# Refolk - User Requirements
 
 **Last updated:** 2026-02-09
 
@@ -189,7 +189,7 @@ A service that provides pre-built, curated digital customer personas that respon
 These are potential future features, not current requirements:
 
 - **Custom persona building by users** - Team/Enterprise can request custom personas, but DIY persona building is not the core flow
-- **Census/polling at scale** - Running surveys across hundreds of twins (future premium feature)
+- **Census/polling at scale** - Running surveys across hundreds of personas (future premium feature)
 - **Analytics/reporting dashboard** - Tracking patterns across conversations
 - **API access for developers** - Team tier and above (future)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-v0-project",
+  "name": "refolk",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Rebrand all in-app copy, meta tags, and docs from "Digital Customer Twins" / "Twins" to "Refolk"
- Replace "twin/twins" terminology with "persona/personas" across all components
- Remove `cis-` references from persona subtitles (fixes #1)
- Update package.json name, README, CLAUDE.md, Stripe docs, and marketing docs

Closes #1
Closes #9

## Files changed (19)
- **Config:** `package.json`, `CLAUDE.md`, `README.md`
- **Components:** `header`, `hero`, `how-it-works`, `personas`, `chat-demo`, `integrations`, `difference`, `pricing`, `use-cases`, `footer`
- **App:** `layout.tsx` (meta title)
- **Docs:** `docs/user/reqs.md`, `docs/tech/stripe-setup.md`, `docs/tech/monetization-setup-complete.md`, `docs/marketing/how-it-works-rewrite.md`, `docs/marketing/cta-guidelines.md`

## Test plan
- [x] `bun run build` passes
- [ ] Visual review of landing page after deploy
- [ ] Verify no remaining "twin/twins" references in user-facing copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)